### PR TITLE
Stateful DisjointSets with path compression and union rank heuristics

### DIFF
--- a/core/src/main/scala/dogs/DisjointSets.scala
+++ b/core/src/main/scala/dogs/DisjointSets.scala
@@ -2,6 +2,7 @@ package dogs
 
 import Predef._
 import cats._
+import cats.data.State
 
 import DisjointSets.Entry
 
@@ -98,11 +99,28 @@ class DisjointSets[T : Order] private(private val entries: Map[T, Entry[T]]) {
 
 }
 
-object DisjointSets {
+object DisjointSets extends DisjointSetsStates {
 
   def apply[T : Order](labels: T*): DisjointSets[T] = new DisjointSets[T](
     Map(labels.map(l => l -> Entry(0, l)):_*)
   )
 
   private case class Entry[T](rank: Int, parent: T)
+}
+
+
+trait DisjointSetsStates {
+
+  def find[T](v: T) = State[DisjointSets[T], Option[T]](
+    disjointSets => disjointSets.find(v)
+  )
+
+  def union[T](a: T, b: T) = State[DisjointSets[T], Boolean](
+    disjointSets => disjointSets.union(a, b)
+  )
+
+  def toSets[T] = State[DisjointSets[T], Map[T, Set[T]]](
+    disjointSets => disjointSets.toSets
+  )
+
 }

--- a/core/src/main/scala/dogs/DisjointSets.scala
+++ b/core/src/main/scala/dogs/DisjointSets.scala
@@ -3,6 +3,7 @@ package dogs
 import Predef._
 import cats._
 import cats.data.State
+import cats.data.State.get
 
 import DisjointSets.Entry
 
@@ -18,7 +19,7 @@ class DisjointSets[T : Order] private(private val entries: Map[T, Entry[T]]) {
     * )
     */
   def union(a: T, b: T): (DisjointSets[T], Boolean) = {
-    import DisjointSets.{find => findSt, get}
+    import DisjointSets.{find => findSt}
 
     val result: Option[DisjointSets[T]] = {
       for {
@@ -125,10 +126,6 @@ trait DisjointSetsStates {
 
   def toSets[T] = State[DisjointSets[T], Map[T, Set[T]]](
     disjointSets => disjointSets.toSets
-  )
-
-  def get[T] = State[DisjointSets[T], DisjointSets[T]](
-    disjointSets => disjointSets -> disjointSets
   )
 
 }

--- a/core/src/main/scala/dogs/DisjointSets.scala
+++ b/core/src/main/scala/dogs/DisjointSets.scala
@@ -1,0 +1,108 @@
+package dogs
+
+import Predef._
+import cats._
+
+import DisjointSets.Entry
+
+class DisjointSets[T : Order] private(private val entries: Map[T, Entry[T]]) {
+
+  /**
+    * Joins two disjoint sets if both are contained by this [[DisjointSets]]
+    *
+    * @param a Set `a`
+    * @param b Set `b`
+    * @return (new [[DisjointSets]] with updated state,
+    *   `true` if Both labels are contained and joined
+    * )
+    */
+  def union(a: T, b: T): (DisjointSets[T], Boolean) = {
+
+    val result: Option[DisjointSets[T]] = {
+      val (phase1, opa) = find(a)
+      for {
+        pa <- opa
+        (phase2, opb) = phase1.find(b)
+        pb <- opb
+      } yield {
+        val Some(((parent, parentEntry), (child, childEntry))) = {
+          import phase2.{entries => flatEntries}
+          for {
+            paEntry <- flatEntries get pa
+            pbEntry <- flatEntries get pb
+          } yield {
+            val parent_child = (pa -> paEntry, pb -> pbEntry)
+            if(paEntry.rank >= pbEntry.rank) parent_child else parent_child.swap
+          }
+        }
+        new DisjointSets[T] (
+          phase2.entries ++ Map(
+            child -> childEntry.copy(parent = parent),
+            parent -> parentEntry.copy(rank = scala.math.max(parentEntry.rank, childEntry.rank+1))
+          )
+        )
+      }
+    }
+    result.getOrElse(this) -> result.isDefined
+
+  }
+
+  /**
+    * Checks whether or not a value is present in the disjoint sets collection
+    * @param v label to be found within the data structure
+    * @return Check result
+    */
+  def contains(v: T): Boolean = entries containsKey v
+
+  /**
+    * Find the label of the provided value.
+    * @param v Value whose label is to be found
+    * @return (new state, 'None' if the value doesn't exist, Some(label) otherwise)
+    */
+  def find(v: T): (DisjointSets[T], Option[T]) = {
+    val newState = entries.get(v) map { _ =>
+      flattenBranch(v)
+    }
+    (newState.getOrElse(this), newState flatMap { st => st.entries.get(v).map(_.parent) })
+  }
+
+  /**
+    * Add a value to this datastructure
+    * @param v Value to be added
+    * @return New [[DisjointSets]]'s state.
+    */
+  def +(v: T): DisjointSets[T] = {
+    if(entries containsKey v) this
+    else new DisjointSets(entries + (v -> Entry(0, v)))
+  }
+
+  /**
+    * Generates a map from labels to sets from
+    * the current [[DisjointSets]].
+    */
+  def toSets: (DisjointSets[T], Map[T, Set[T]]) =
+    entries.foldLeft((this, Map[T, Set[T]]())) {
+      case ((dsets, acc), (k, _)) =>
+        val (newSt, Some(label)) = dsets.find(k)
+        val updatedSet = acc.get(label).getOrElse(Set.empty[T]) + k
+        (newSt, acc + (label -> updatedSet))
+    }
+
+  private def flattenBranch(label: T, toPropagate: Map[T, Entry[T]] = Map.empty): DisjointSets[T] =
+    entries.get(label) match {
+      case Some(Entry(_, parent)) if parent == label =>
+        val newEntries = entries ++ toPropagate
+        new DisjointSets(newEntries)
+      case Some(entry @ Entry(_, parent)) => flattenBranch(parent, toPropagate + (label -> entry))
+    }
+
+}
+
+object DisjointSets {
+
+  def apply[T : Order](labels: T*): DisjointSets[T] = new DisjointSets[T](
+    Map(labels.map(l => l -> Entry(0, l)):_*)
+  )
+
+  private case class Entry[T](rank: Int, parent: T)
+}

--- a/docs/src/main/tut/disjointsets.md
+++ b/docs/src/main/tut/disjointsets.md
@@ -3,7 +3,7 @@ layout: default
 title:  "DisjointSets"
 source: "core/src/main/scala/dogs/DisjointSets.scala"
 ---
-#Disjoint Sets
+# Disjoint Sets
 
 `DisjointSets` provides a purely functional implementation for the union-find collection. 
 An Union-Find (aka Disjoint Sets) structure is a set of sets where the intersection of any two sets is empty.
@@ -17,7 +17,7 @@ This constraint opens the way to fast unions (`O(1)` average). That makes of Dis
  
 Initially, it is a flat collection where each element forms its own, size 1, disjoint set.
 New elements are added as new disjoint sets and union operations can be used to fusion these sets.
-The joined sets are represented by one of its elements known as *label* or *root*.
+The joined sets are represented by one of its elements known as ***label* or *root***. 
 
 Fast fusion of disjoints sets is key and its provided through parenthood relations. Sets `labels` are always the 
 top-level ancestor.
@@ -26,7 +26,7 @@ The following example shows 3 disjoint sets of size 1.
 
 ![](http://i.imgur.com/h8ddOkT.png)
 
-Whereas, in the next one, `C` is the parent of the `{A, B, C}` set which the single set in the DisjointSets structure. 
+Whereas, in the next one, `C` is the parent of the `{A, B, C}` set which is the only set in the DisjointSets structure. 
 
 ![](http://i.imgur.com/V71Z0eS.png)
 
@@ -41,7 +41,7 @@ Whereas, in the next one, `C` is the parent of the `{A, B, C}` set which the sin
 ![](http://i.imgur.com/7uunsNJ.png)
 
 
-- `dsets.find(v)` (find): Retrieves the `Some(label)` if `v` belongs to the set with that label or `None` if the 
+- `dsets.find(v)` (find): Retrieves `Some(label)` if `v` belongs to the set with that label or `None` if the 
 value is not part of `dsets`.
 
 - `dsets.toSets`: Gets a `Map[T, Set[T]]` representation of the DisjointSets contents where the key is each set 
@@ -66,11 +66,14 @@ val label2disjointset: Map[Int, Set[Int]] = operations.runA(DisjointSets(1,2,3,4
 
 ## Structure and performance 
 
-The main idea is that each element starts as a disjoint set itself. A set with two or more elements is always the result of one or several _union_ operations. Thus, a multi-element set is composed of sets of just one element, call them components. Each component has to fields:
+The main idea is that each element starts as a disjoint set itself. A set with two or more elements is always the result of one or several _union_ operations. Thus, a multi-element set is composed of sets of just one element, call them components. 
+
+Each component has 3 fields:
 
 - One for the value of the element it contains.
-- A reference pointing to another component of the same composed multi-element set.
-Three one-element disjoint sets.
+- A reference pointing to another component of the same composed multi-element set. Or itself if it constitutes a single element set.
+- An estimation of how many components/nodes compose its descendants. This estimation is known as **rank**.
+
 
 Let’s assume that the next operations are executed:
 
@@ -89,8 +92,8 @@ operations, the resulting structure after (1) and (2) is:
 ![](http://i.imgur.com/9srckn2.png)
 
 Each set is a tree represented by its _root_. Therefore, looking for the set an element belongs to is not more than 
-following its parental relations until the root of the tree is reached. So the shallower the tree is the smaller is 
-the number of operations to be performed in the lookup.
+following its parental relations until the root of the tree is reached. So the shallower the tree is, the fewer
+the operations to be performed in the lookup are.
 
 On the other hand, the operation where two sets are merged (_union_) consist on making one of the two trees to become a 
 branch of the other:
@@ -110,11 +113,10 @@ jumps from the deepest leaf to its tree root. That is ![](http://i.imgur.com/DR5
 
 There are two heuristics designed to keep these tress low:
 
-- Union by rank:  Avoids incrementing ![](http://i.imgur.com/DR5IUP3.png) whenever possible. The idea is for each 
+- **Union by rank:**  Avoids incrementing ![](http://i.imgur.com/DR5IUP3.png) whenever possible. The idea is for each 
 value node to store how many levels have the sub-tree that they are ancestor of (call it rank). All new elements 
 have a rank value of 0 (the _root_ is the first level). This way, whenever an _union_ operation is 
-executed, is the shorter tree the one that becomes a branch of the other and, therefore, ![](http://i.imgur
-.com/DR5IUP3.png) does not increase.
-- Path compression: In this case the aim is to take advantage of the jumps made in _find_ operation. Whenever a tree 
+executed, is the shorter tree the one that becomes a branch of the other and, therefore, ![](http://i.imgur.com/DR5IUP3.png) does not increase.
+- **Path compression:** In this case the aim is to take advantage of the jumps made in _find_ operation. Whenever a tree 
 _root_ is found it is assigned to every node in the search path. This is a purely functional data structure so the 
-changtes are reflected in a new copy of it which forms part of the operation result.
+changes are reflected in a new copy of it which forms part of the operation result.

--- a/docs/src/main/tut/disjointsets.md
+++ b/docs/src/main/tut/disjointsets.md
@@ -1,0 +1,120 @@
+---
+layout: default
+title:  "DisjointSets"
+source: "core/src/main/scala/dogs/DisjointSets.scala"
+---
+#Disjoint Sets
+
+`DisjointSets` provides a purely functional implementation for the union-find collection. 
+An Union-Find (aka Disjoint Sets) structure is a set of sets where the intersection of any two sets is empty.
+
+![](http://i.imgur.com/K7BwoOk.png)
+
+![](http://i.imgur.com/SkqEdwt.png)
+
+This constraint opens the way to fast unions (`O(1)` average). That makes of Disjoint Sets the perfect tool for
+ clustering algorithms such as calculating the connected components in a graph.
+ 
+Initially, it is a flat collection where each element forms its own, size 1, disjoint set.
+New elements are added as new disjoint sets and union operations can be used to fusion these sets.
+The joined sets are represented by one of its elements known as *label* or *root*.
+
+Fast fusion of disjoints sets is key and its provided through parenthood relations. Sets `labels` are always the 
+top-level ancestor.
+
+The following example shows 3 disjoint sets of size 1.
+
+![](http://i.imgur.com/h8ddOkT.png)
+
+Whereas, in the next one, `C` is the parent of the `{A, B, C}` set which the single set in the DisjointSets structure. 
+
+![](http://i.imgur.com/V71Z0eS.png)
+
+## Supported operations
+
+- `dsets + c` (add): Adds a value as a single element set:
+
+![](http://i.imgur.com/iA00VgQ.png)
+
+- `desets.union(A,C)` (union/join): Fusion two disjoint sets:
+
+![](http://i.imgur.com/7uunsNJ.png)
+
+
+- `dsets.find(v)` (find): Retrieves the `Some(label)` if `v` belongs to the set with that label or `None` if the 
+value is not part of `dsets`.
+
+- `dsets.toSets`: Gets a `Map[T, Set[T]]` representation of the DisjointSets contents where the key is each set 
+*label*. 
+ 
+## Example usage
+
+```scala
+import DisjointSets._
+
+val operations = for {
+  _ <- union(1,2)
+  oneAndTwo <- find(2)
+  _ <- union(3,4)
+  threeAndFour <- find(3)
+  _ <- union(2,3)
+  sets <- toSets
+} yield sets
+
+val label2disjointset: Map[Int, Set[Int]] = operations.runA(DisjointSets(1,2,3,4)).value
+```
+
+## Structure and performance 
+
+The main idea is that each element starts as a disjoint set itself. A set with two or more elements is always the result of one or several _union_ operations. Thus, a multi-element set is composed of sets of just one element, call them components. Each component has to fields:
+
+- One for the value of the element it contains.
+- A reference pointing to another component of the same composed multi-element set.
+Three one-element disjoint sets.
+
+Let’s assume that the next operations are executed:
+
+```
+dsets.union(B,A) //1
+dsets.union(B,C) //2
+```
+
+From a mathematical point of view, the result should be similar to the one shown below:
+
+![](http://i.imgur.com/V71Z0eS.png)
+
+However, in order to improve lookups performance, some optimizations need to be applied. Therefore, with optimized 
+operations, the resulting structure after (1) and (2) is:
+
+![](http://i.imgur.com/9srckn2.png)
+
+Each set is a tree represented by its _root_. Therefore, looking for the set an element belongs to is not more than 
+following its parental relations until the root of the tree is reached. So the shallower the tree is the smaller is 
+the number of operations to be performed in the lookup.
+
+On the other hand, the operation where two sets are merged (_union_) consist on making one of the two trees to become a 
+branch of the other:
+
+![](http://i.imgur.com/aKHPrtV.png)
+
+
+### Heuristics
+
+These are two optimizations whose goal is to reduce the depth of each tree representing a set. The lower the tree height is, 
+the fewer operations are needed to find one element set  label.
+
+Considering `DisjointSets` structure as a forest of tree-sets, let’s compute ![](http://i.imgur.com/wgbq86Y.png) as the maximum tree height of the 
+forest.
+The maximum number of operations to complete before finding one element in one set is proportional to the number of 
+jumps from the deepest leaf to its tree root. That is ![](http://i.imgur.com/DR5IUP3.png).
+
+There are two heuristics designed to keep these tress low:
+
+- Union by rank:  Avoids incrementing ![](http://i.imgur.com/DR5IUP3.png) whenever possible. The idea is for each 
+value node to store how many levels have the sub-tree that they are ancestor of (call it rank). All new elements 
+have a rank value of 0 (the _root_ is the first level). This way, whenever an _union_ operation is 
+executed, is the shorter tree the one that becomes a branch of the other and, therefore, ![](http://i.imgur
+.com/DR5IUP3.png) does not increase.
+- Path compression: In this case the aim is to take advantage of the jumps made in _find_ operation. Whenever a tree 
+_root_ is found it is assigned to every node in the search path. This is a purely functional data structure so the 
+changtes are reflected in a new copy of it which forms part of the operation result.

--- a/tests/src/test/scala/DisjointSetsSpec.scala
+++ b/tests/src/test/scala/DisjointSetsSpec.scala
@@ -44,7 +44,7 @@ class DisjointSetsSpec extends DogsSuite with ArbitraryList {
 
   }
 
-  test("build unions as a set of sets was used") {
+  test("build unions with disjoint sets as if a set of sets were used") {
 
     import scala.collection.immutable.Range
 

--- a/tests/src/test/scala/DisjointSetsSpec.scala
+++ b/tests/src/test/scala/DisjointSetsSpec.scala
@@ -1,0 +1,64 @@
+package dogs
+package tests
+
+import Predef._
+import dogs.tests.arbitrary._
+import cats.implicits._
+
+
+class DisjointSetsSpec extends DogsSuite with ArbitraryList {
+
+  test("union-find operations using state/stator monad") {
+
+    import DisjointSets._
+
+    val operations = for {
+      _ <- union(1,2)
+      oneAndTwo <- find(2)
+      _ <- union(3,4)
+      threeAndFour <- find(3)
+      _ <- union(2,3)
+      allFromOne <- find(1)
+      allFromTwo <- find(2)
+      allFromThree <- find(3)
+      allFromFour <- find(4)
+    } yield (
+      oneAndTwo,
+      threeAndFour,
+      allFromOne, allFromTwo, allFromThree, allFromFour
+    )
+
+    val (
+      Some(a),
+      Some(b),
+      Some(c),
+      Some(d),
+      Some(e),
+      Some(f)
+    ) = operations.runA(DisjointSets(1,2,3,4)).value
+
+    a should not equal (b)
+    c shouldBe d
+    d shouldBe e
+    e shouldBe f
+
+  }
+
+  test("build unions as a set of sets was used") {
+
+    import scala.collection.immutable.Range
+
+    val numbers = Range(0,200)
+
+    val classifiedNumbers = (DisjointSets(numbers:_*) /: numbers) { (dsets, v) =>
+      dsets.union(v, v%10)._1
+    }
+
+    val groupByClassification = numbers.groupBy(_ % 10).mapValues(_.toSet)
+    val (_, disjointSetsClassification) = classifiedNumbers.toSets
+
+
+    disjointSetsClassification.toScalaMap.mapValues(_.toScalaSet) should contain theSameElementsAs groupByClassification
+  }
+
+}


### PR DESCRIPTION
This PR tries to bring a purely functional implementation of DisjointSets to Dogs. Including the optimizations resulting from the application of path compression and union rank heuristics as described in _[CLRS](https://en.wikipedia.org/wiki/Introduction_to_Algorithms) [Chapter V, Section 21.3 - Disjoint Sets Forests]_

There is a quick recap at http://orionsword.no-ip.org/blog/wordpress/?p=246 

This PR aims is the same as https://github.com/stew/dogs/pull/86 with the following differences:

- It offers an slightly different interface which also include `toSets` methods.
- It adds path compression for each `find` look-up.
- It also adds `State[DisjointSets[T], _]` functions which serve as a purely functional and stateful interface which allows leveraging `for` notation to seamlessly work with the data structure changes. e.g:

```scala
import DisjointSets._

val operations = for {
  _ <- union(1,2)
  oneAndTwo <- find(2)
  _ <- union(3,4)
  threeAndFour <- find(3)
  _ <- union(2,3)
  sets <- toSets
} yield sets

val label2disjointset: Map[Int, Set[Int]] = operations.runA(DisjointSets(1,2,3,4)).value
```
- It leverages the stateful find operation to implement `union` as:
```scala
  /**
    * Joins two disjoint sets if both are contained by this [[DisjointSets]]
    *
    * @param a Set `a`
    * @param b Set `b`
    * @return (new [[DisjointSets]] with updated state,
    *   `true` if Both labels are contained and joined
    * )
    */
  def union(a: T, b: T): (DisjointSets[T], Boolean) = {
    import DisjointSets.{find => findSt, get}

    val result: Option[DisjointSets[T]] = {
      for {
        opa <- findSt(a) // Find `a` parent's label, track path compression
        opb <- findSt(b) // Find `b` parent's label, track path compression
        dsets <- get // Get the state (the compressed [[DisjointSets]])
      } yield for {
        pa <- opa // If `a` was part of the collection
        pb <- opb // As well as `b`...
        flatEntries = dsets.entries
        paEntry <- flatEntries get pa //then their ranks are recovered...
        pbEntry <- flatEntries get pb
      } yield {
        val ((parent, parentEntry), (child, childEntry)) = {
          //... so it is possible to determine which one should be placed below
          //the other minimizing the resulting tree depth
          val parent_child = (pa -> paEntry, pb -> pbEntry)
          if(paEntry.rank >= pbEntry.rank) parent_child else parent_child.swap
        }
        new DisjointSets[T] (
          flatEntries ++ Map(
            child -> childEntry.copy(parent = parent),
            parent -> parentEntry.copy(rank = scala.math.max(parentEntry.rank, childEntry.rank+1))
          )
        )
      }
    }.runA(this).value

    result.getOrElse(this) -> result.isDefined

  }
```
Documentation has been added as well as a couple of tests. I am open to any suggestion or improvement. 