### PR TITLE
Added emacs ensime cache directory to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ project/boot
 target
 .ensime
 .ensime_lucene
+.ensime_cache
 TAGS
 \#*#
 *~


### PR DESCRIPTION
When Emacs is used along side of Ensime, it creates a local directory  `.ensime_cache` which is not listed in this project `.gitignore` file thus showing changes to stage. 

Ths PR adds that entry to the git ignore file.