### PR TITLE
Fix short-circuiting of Streaming traverse

### DIFF
--- a/core/src/main/scala/dogs/Streaming.scala
+++ b/core/src/main/scala/dogs/Streaming.scala
@@ -923,11 +923,8 @@ private[dogs] sealed trait StreamingInstances extends StreamingInstances1 {
         // We use foldRight to avoid possible stack overflows. Since
         // we don't want to return a Eval[_] instance, we call .value
         // at the end.
-        //
-        // (We don't worry about internal laziness because traverse
-        // has to evaluate the entire stream anyway.)
-        foldRight(fa, Later(init)) { (a, lgsb) =>
-          lgsb.map(gsb => G.map2(f(a), gsb) { (a, s) => Streaming.cons(a, s) })
+        foldRight(fa, Always(init)) { (a, lgsb) =>
+          G.map2Eval(f(a), lgsb)(Streaming.cons(_, _))
         }.value
       }
 

--- a/tests/src/test/scala/StreamingTests.scala
+++ b/tests/src/test/scala/StreamingTests.scala
@@ -468,4 +468,8 @@ class AdHocStreamingTests extends DogsSuite {
   test("lazy tails") {
     isok(bomb.tails)
   }
+
+  test("traverse short-circuits") {
+    dangerous.traverse(i => if (i < 3) Some(i) else None) shouldBe None
+  }
 }


### PR DESCRIPTION
This fixes the short-circuiting of the `traverse` implementation for
`Streaming`.

Note that it doesn't address the separate issue described in #98. I'm
not sure that fixing #98 in a stack-safe way is possible with the
current definition of `Applicative`.