### PR TITLE
Removed warnings from sites generated by sbt-microsites

### DIFF
--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -52,5 +52,7 @@ scalacOptions := Seq(
   "-Yno-adapted-args",
   "-Ywarn-dead-code",
   "-Ywarn-value-discard",
-  "-Xfuture")
+  "-Xfuture",
+  "-nowarn")
+
 


### PR DESCRIPTION
Warning such as unused imports made reading documentation unpleasant, so I  switched the warnings off.

This pull request fixes #100 

## Before
<img width="857" alt="zrzut ekranu 2017-12-26 o 10 45 20" src="https://user-images.githubusercontent.com/1032987/34353690-f276e590-ea29-11e7-8551-cd0c7b0fd90f.png">

## After
<img width="769" alt="zrzut ekranu 2017-12-26 o 10 46 19" src="https://user-images.githubusercontent.com/1032987/34353714-0e65ae62-ea2a-11e7-9707-a52b24a558a4.png">
