### PR TITLE
Scala 3.8+ accommodations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,18 +28,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        scala: [3, 2.13, 2.12]
+        scala: [3.8.1, 3.3.7, 2.13.18, 2.12.21]
         java: [temurin@8, temurin@21]
         project: [rootJS, rootJVM, rootNative]
         exclude:
-          - scala: 3
-            java: temurin@21
-          - scala: 2.13
-            java: temurin@21
-          - project: rootJS
-            java: temurin@21
-          - project: rootNative
-            java: temurin@21
+          - scala: 3.8.1
+            java: temurin@8
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -162,92 +156,92 @@ jobs:
         if: matrix.java == 'temurin@21' && steps.setup-java-temurin-21.outputs.cache-hit == 'false'
         run: sbt +update
 
-      - name: Download target directories (3, rootJS)
+      - name: Download target directories (3.3.7, rootJS)
         uses: actions/download-artifact@v6
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3-rootJS
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.3.7-rootJS
 
-      - name: Inflate target directories (3, rootJS)
+      - name: Inflate target directories (3.3.7, rootJS)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3, rootJVM)
+      - name: Download target directories (3.3.7, rootJVM)
         uses: actions/download-artifact@v6
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3-rootJVM
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.3.7-rootJVM
 
-      - name: Inflate target directories (3, rootJVM)
+      - name: Inflate target directories (3.3.7, rootJVM)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3, rootNative)
+      - name: Download target directories (3.3.7, rootNative)
         uses: actions/download-artifact@v6
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3-rootNative
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.3.7-rootNative
 
-      - name: Inflate target directories (3, rootNative)
+      - name: Inflate target directories (3.3.7, rootNative)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.13, rootJS)
+      - name: Download target directories (2.13.18, rootJS)
         uses: actions/download-artifact@v6
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13-rootJS
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.18-rootJS
 
-      - name: Inflate target directories (2.13, rootJS)
+      - name: Inflate target directories (2.13.18, rootJS)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.13, rootJVM)
+      - name: Download target directories (2.13.18, rootJVM)
         uses: actions/download-artifact@v6
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13-rootJVM
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.18-rootJVM
 
-      - name: Inflate target directories (2.13, rootJVM)
+      - name: Inflate target directories (2.13.18, rootJVM)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.13, rootNative)
+      - name: Download target directories (2.13.18, rootNative)
         uses: actions/download-artifact@v6
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13-rootNative
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.18-rootNative
 
-      - name: Inflate target directories (2.13, rootNative)
+      - name: Inflate target directories (2.13.18, rootNative)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.12, rootJS)
+      - name: Download target directories (2.12.21, rootJS)
         uses: actions/download-artifact@v6
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12-rootJS
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.21-rootJS
 
-      - name: Inflate target directories (2.12, rootJS)
+      - name: Inflate target directories (2.12.21, rootJS)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.12, rootJVM)
+      - name: Download target directories (2.12.21, rootJVM)
         uses: actions/download-artifact@v6
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12-rootJVM
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.21-rootJVM
 
-      - name: Inflate target directories (2.12, rootJVM)
+      - name: Inflate target directories (2.12.21, rootJVM)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.12, rootNative)
+      - name: Download target directories (2.12.21, rootNative)
         uses: actions/download-artifact@v6
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12-rootNative
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.21-rootNative
 
-      - name: Inflate target directories (2.12, rootNative)
+      - name: Inflate target directories (2.12.21, rootNative)
         run: |
           tar xf targets.tar
           rm targets.tar
@@ -322,7 +316,7 @@ jobs:
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
-          modules-ignore: rootjs_3 rootjs_2.13 rootjs_2.12 docs_3 docs_2.13 docs_2.12 cats-collections-tests_sjs1_3 cats-collections-tests_sjs1_2.13 cats-collections-tests_sjs1_2.12 rootjvm_3 rootjvm_2.13 rootjvm_2.12 rootnative_3 rootnative_2.13 rootnative_2.12 cats-collections-tests_3 cats-collections-tests_2.13 cats-collections-tests_2.12 cats-collections-tests_native0.5_3 cats-collections-tests_native0.5_2.13 cats-collections-tests_native0.5_2.12 cats-collections-bench_3 cats-collections-bench_2.13 cats-collections-bench_2.12
+          modules-ignore: rootjs_3 rootjs_3 rootjs_2.13 rootjs_2.12 docs_3 docs_3 docs_2.13 docs_2.12 cats-collections-tests_sjs1_3 cats-collections-tests_sjs1_3 cats-collections-tests_sjs1_2.13 cats-collections-tests_sjs1_2.12 rootjvm_3 rootjvm_3 rootjvm_2.13 rootjvm_2.12 rootnative_3 rootnative_3 rootnative_2.13 rootnative_2.12 cats-collections-tests_3 cats-collections-tests_3 cats-collections-tests_2.13 cats-collections-tests_2.12 cats-collections-tests_native0.5_3 cats-collections-tests_native0.5_3 cats-collections-tests_native0.5_2.13 cats-collections-tests_native0.5_2.12 cats-collections-bench_3 cats-collections-bench_3 cats-collections-bench_2.13 cats-collections-bench_2.12
           configs-ignore: test scala-tool scala-doc-tool test-internal
 
   coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
         exclude:
           - scala: 3.8.1
             java: temurin@8
+          - project: rootJS
+            java: temurin@21
+          - project: rootNative
+            java: temurin@21
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,9 @@ ThisBuild / tlCiReleaseBranches := Seq("master")
 ThisBuild / tlSitePublishBranch := Some("master")
 ThisBuild / githubWorkflowJavaVersions := Seq("8", "21").map(JavaSpec.temurin)
 ThisBuild / githubWorkflowBuildMatrixExclusions := Seq(
-  MatrixExclude(matching = Map("scala" -> Scala3, "java" -> "temurin@8"))
+  MatrixExclude( Map( "scala" -> Scala3, "java" -> "temurin@8")),
+  MatrixExclude( Map( "project" -> "rootJS", "java" -> "temurin@21")),
+  MatrixExclude( Map( "project" -> "rootNative", "java" -> "temurin@21"))
 )
 ThisBuild / githubWorkflowAddedJobs +=
   WorkflowJob(

--- a/build.sbt
+++ b/build.sbt
@@ -8,17 +8,21 @@ val algebraVersion = "2.13.0"
 
 val Scala212 = "2.12.21"
 val Scala213 = "2.13.18"
-val Scala3 = "3.3.7"
+val Scala3LTS = "3.3.7"
+val Scala3 = "3.8.1"
 
 ThisBuild / tlBaseVersion := "0.9"
 ThisBuild / startYear := Some(2015)
 
-ThisBuild / crossScalaVersions := Seq(Scala3, Scala213, Scala212)
+ThisBuild / crossScalaVersions := Seq(Scala3, Scala3LTS, Scala213, Scala212)
 ThisBuild / tlVersionIntroduced := Map("3" -> "0.9.3")
 ThisBuild / tlFatalWarnings := false
 ThisBuild / tlCiReleaseBranches := Seq("master")
 ThisBuild / tlSitePublishBranch := Some("master")
 ThisBuild / githubWorkflowJavaVersions := Seq("8", "21").map(JavaSpec.temurin)
+ThisBuild / githubWorkflowBuildMatrixExclusions := Seq(
+  MatrixExclude(matching = Map("scala" -> Scala3, "java" -> "temurin@8"))
+)
 ThisBuild / githubWorkflowAddedJobs +=
   WorkflowJob(
     "coverage",


### PR DESCRIPTION
Upgrade to 3.8.1 requires JVM 17+, which should be handled separately in a build process.
Also, it seems worth it to introduce a Scala 3 LTS version into the pipeline.